### PR TITLE
Mac os sed version causing errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-VERSION := $(shell sed '/version/ b e; d; b; :e s/ *"version": "\([^"]*\)",/\1/ ' package.json)
+SHELL = sh
+VERSSION := $(shell sed -n 's/ *"version": "\([^"]*\)",/\1/p;' package.json)
+PATH	:= $(PWD)/node_modules/.bin:$(PATH)
+
 
 blackboardjs-$(VERSION).tgz:
 	npm pack

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "devDependencies": {
     "jshint-junit-reporter": "",
     "grunt": "",
+    "grunt-cli": "",
     "grunt-contrib-jshint": "",
     "grunt-contrib-uglify": "",
     "grunt-contrib-jasmine": "~0.5.2",


### PR DESCRIPTION
 Mac Os does not use the gnu version of sed resulting in
 errors when lables are defined after use.
- Update to Makefile version extraction sed script to be
  crossplatform compatible
- Added grunt-cli to requirements and updated path in make
  to use local version instead of global.
